### PR TITLE
Feat#4 http

### DIFF
--- a/msa_service1/build.gradle
+++ b/msa_service1/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	//feign 통신을 위한 라이브러리
+	implementation group: 'org.springframework.cloud', name: 'spring-cloud-starter-openfeign'
 }
 
 tasks.named('test') {

--- a/msa_service1/src/main/java/com/example/msa_service1/MsaService1Application.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/MsaService1Application.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
-@EnableDiscoveryClient
+//@EnableDiscoveryClient
 @EnableFeignClients //feign 통신
 public class MsaService1Application {
 

--- a/msa_service1/src/main/java/com/example/msa_service1/MsaService1Application.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/MsaService1Application.java
@@ -4,11 +4,13 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableDiscoveryClient
+@EnableFeignClients //feign 통신
 public class MsaService1Application {
 
 	// restTemplate을 빈으로 등록하여 RestTemplate에 Ribbon 탑재

--- a/msa_service1/src/main/java/com/example/msa_service1/MsaService1Application.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/MsaService1Application.java
@@ -3,10 +3,20 @@ package com.example.msa_service1;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.client.loadbalancer.LoadBalanced;
+import org.springframework.context.annotation.Bean;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableDiscoveryClient
 public class MsaService1Application {
+
+	// restTemplate을 빈으로 등록하여 RestTemplate에 Ribbon 탑재
+	@LoadBalanced
+	@Bean
+	public RestTemplate getRestTemplate() {
+		return new RestTemplate();
+	}
 
 	public static void main(String[] args) {
 		SpringApplication.run(MsaService1Application.class, args);

--- a/msa_service1/src/main/java/com/example/msa_service1/controller/DiscoveryController.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/controller/DiscoveryController.java
@@ -31,4 +31,10 @@ public class DiscoveryController {
         return discoveryService.ribbon(id);
     }
 
+    //feign 적용
+    @GetMapping("/feign/{id}")
+    public String feign(@PathVariable("id") String id) {
+        return discoveryService.feign(id);
+    }
+
 }

--- a/msa_service1/src/main/java/com/example/msa_service1/controller/DiscoveryController.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/controller/DiscoveryController.java
@@ -24,4 +24,11 @@ public class DiscoveryController {
     public String resttemplate(@PathVariable("id") String id) {
         return discoveryService.resttemplate(id);
     }
+
+    // ribbon 적용
+    @GetMapping("/ribbon/{id}")
+    public String ribbon(@PathVariable("id") String id) {
+        return discoveryService.ribbon(id);
+    }
+
 }

--- a/msa_service1/src/main/java/com/example/msa_service1/controller/DiscoveryController.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/controller/DiscoveryController.java
@@ -3,6 +3,7 @@ package com.example.msa_service1.controller;
 import com.example.msa_service1.service.DiscoveryService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -15,5 +16,12 @@ public class DiscoveryController {
     @GetMapping("/services")
     public List<String> services() {
         return discoveryService.getServices();
+    }
+
+
+    // restTemplate 적용
+    @GetMapping("/resttemplate/{id}")
+    public String resttemplate(@PathVariable("id") String id) {
+        return discoveryService.resttemplate(id);
     }
 }

--- a/msa_service1/src/main/java/com/example/msa_service1/http/FeignClientCommunicator.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/http/FeignClientCommunicator.java
@@ -1,0 +1,13 @@
+package com.example.msa_service1.http;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+
+@FeignClient("service2")
+public interface FeignClientCommunicator {
+
+    @RequestMapping(method = RequestMethod.GET, value = "/name/{id}")
+    String getName(@PathVariable("id") String id);
+}

--- a/msa_service1/src/main/java/com/example/msa_service1/http/FeignClientCommunicator.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/http/FeignClientCommunicator.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
-@FeignClient("service2")
+@FeignClient("service2") //서비스 2로 api 호출한다고 명시
 public interface FeignClientCommunicator {
 
     @RequestMapping(method = RequestMethod.GET, value = "/name/{id}")

--- a/msa_service1/src/main/java/com/example/msa_service1/http/RestTemplateClientCommunicator.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/http/RestTemplateClientCommunicator.java
@@ -1,0 +1,40 @@
+package com.example.msa_service1.http;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+
+@Component
+public class RestTemplateClientCommunicator {
+
+    @Autowired
+    private DiscoveryClient discoveryClient;
+
+    public String getName(String id) {
+
+        RestTemplate restTemplate = new RestTemplate(); //restTemplate 객체를 생성하여 IP와 PORT로 직접 호출
+        // discoveryClient를 이용하여 서비스 2의 ID와 PORT를 가져와서 api 호출하는 방식
+        List<ServiceInstance> instances = discoveryClient.getInstances("service2");
+
+        if (instances.size() == 0) {
+            return  null;
+        }
+
+        String serviceUrl = String.format("%s/name/%s", instances.get(0).getUri().toString(), id);
+
+        ResponseEntity<String> restExchange =
+                restTemplate.exchange(
+                        serviceUrl,
+                        HttpMethod.GET,
+                        null,
+                        String.class, id);
+
+        return id + "is" + restExchange.getBody();
+    }
+}

--- a/msa_service1/src/main/java/com/example/msa_service1/http/RibbonClientCommunicator.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/http/RibbonClientCommunicator.java
@@ -1,0 +1,27 @@
+package com.example.msa_service1.http;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class RibbonClientCommunicator {
+
+    @Autowired
+    RestTemplate restTemplate;
+
+    // IP와 PORT대신 서비스2의 고유명인 Service2로 호출하면 Ribbon이 내부적으로 IP와 PORT를 찾아서 처리
+    // 만약 서비스2가 여러개의 인스턴스로 이중화 구성되어있다면 소프트웨어적 로드밸런싱 해줌
+    public String getName(String id) {
+        ResponseEntity<String> restExchange =
+                restTemplate.exchange(
+                        "http://service2/name/{id}",
+                        HttpMethod.GET,
+                        null,
+                        String.class, id);
+
+        return id + "is" + restExchange.getBody();
+    }
+}

--- a/msa_service1/src/main/java/com/example/msa_service1/service/DiscoveryService.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/service/DiscoveryService.java
@@ -1,6 +1,8 @@
 package com.example.msa_service1.service;
 
 
+import com.example.msa_service1.http.RestTemplateClientCommunicator;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.stereotype.Service;
@@ -10,10 +12,14 @@ import java.util.List;
 
 // 유레카 서버에 등록된 서비스 목록을 가져오는 코드
 @Service
+@Slf4j
 public class DiscoveryService {
 
     @Autowired
     private DiscoveryClient discoveryClient;
+
+    @Autowired
+    RestTemplateClientCommunicator restTemplateClientCommunicator;
 
     public List getServices() {
         List<String> services = new ArrayList<String>();
@@ -24,6 +30,12 @@ public class DiscoveryService {
             });
         });
         return services;
+    }
+
+    // restTemplate 적용
+    public String resttemplate(String id) {
+        log.info("restTemplateClientCommunicator로 통신");
+        return restTemplateClientCommunicator.getName(id);
     }
 
 }

--- a/msa_service1/src/main/java/com/example/msa_service1/service/DiscoveryService.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/service/DiscoveryService.java
@@ -2,6 +2,7 @@ package com.example.msa_service1.service;
 
 
 import com.example.msa_service1.http.RestTemplateClientCommunicator;
+import com.example.msa_service1.http.RibbonClientCommunicator;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
@@ -21,6 +22,9 @@ public class DiscoveryService {
     @Autowired
     RestTemplateClientCommunicator restTemplateClientCommunicator;
 
+    @Autowired
+    RibbonClientCommunicator ribbonClientCommunicator;
+
     public List getServices() {
         List<String> services = new ArrayList<String>();
 
@@ -38,5 +42,10 @@ public class DiscoveryService {
         return restTemplateClientCommunicator.getName(id);
     }
 
+    // ribbon 적용
+    public String ribbon(String id) {
+        log.info("ribbonClientCommunicator로 통신");
+        return ribbonClientCommunicator.getName(id);
+    }
 }
 

--- a/msa_service1/src/main/java/com/example/msa_service1/service/DiscoveryService.java
+++ b/msa_service1/src/main/java/com/example/msa_service1/service/DiscoveryService.java
@@ -1,6 +1,7 @@
 package com.example.msa_service1.service;
 
 
+import com.example.msa_service1.http.FeignClientCommunicator;
 import com.example.msa_service1.http.RestTemplateClientCommunicator;
 import com.example.msa_service1.http.RibbonClientCommunicator;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +26,9 @@ public class DiscoveryService {
     @Autowired
     RibbonClientCommunicator ribbonClientCommunicator;
 
+    @Autowired
+    FeignClientCommunicator feignClientCommunicator;
+
     public List getServices() {
         List<String> services = new ArrayList<String>();
 
@@ -46,6 +50,12 @@ public class DiscoveryService {
     public String ribbon(String id) {
         log.info("ribbonClientCommunicator로 통신");
         return ribbonClientCommunicator.getName(id);
+    }
+
+    //feign 적용
+    public String feign(String id) {
+        log.info("feignClientCommunicator로 통신");
+        return feignClientCommunicator.getName(id);
     }
 }
 


### PR DESCRIPTION
 ✨제목 (Title)
RestTemplate, Ribbon, Feign을 활용한 서비스 간 HTTP 통신 방식 구현

🔍 변경 내용 (Changes)
서비스 간 HTTP 통신에서 RestTemplate, Ribbon, Feign을 적용.
Eureka Server와 통합하여 동적 서비스 디스커버리 및 로드 밸런싱 기능 추가.

🛠 구현 방법 (How was this implemented?)

RestTemplate 적용:
기본적인 HTTP 클라이언트로 API 호출 기능 구현.
Spring의 RestTemplate Bean을 정의하고, 이를 통해 서비스 간 통신 처리.

Ribbon 적용:
클라이언트 측 로드 밸런싱 지원.
Eureka Server와 연계하여 동적으로 가용한 인스턴스를 선택해 통신.

Feign 적용:
선언적 HTTP 클라이언트 사용.
서비스 호출 로직을 간결하게 작성하고, Ribbon과 통합하여 로드 밸런싱 활성화.

Eureka Server 통합:
Eureka Server를 활용해 각 서비스가 동적으로 등록 및 검색되도록 설정.
서비스 간 통신이 동적으로 이루어질 수 있도록 구성.

🧪 테스트 (Testing)
사용된 테스트 도구 및 환경:
postman

🚀 관련 이슈 (Related Issues)
#4 

✅ 체크리스트 (Checklist)
PR 작성 후 아래 항목들을 확인하세요:

[o] 코드가 정상적으로 빌드됨
[o] 변경된 코드에 대해 충분한 테스트 완료
[o] 관련 문서가 최신 상태로 업데이트됨 (필요 시)
[o] 팀원 리뷰 요청 및 논의 완료

🤔 추가 코멘트 (Additional Comments)
없음